### PR TITLE
Fix kss version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette-kss-builder",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette-kss-builder",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "The Colette’s Twig.js builder for kss-node.",
   "author": "20 Minutes <web-tech@20minutes.fr>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-cli": "^3.3.10"
   },
   "peerDependencies": {
-    "kss": "3.0.0-beta.20"
+    "kss": "^3.0.0"
   },
   "dependencies": {
     "details-element-polyfill": "^2.4.0",

--- a/readme.md
+++ b/readme.md
@@ -30,3 +30,9 @@ module.exports = {
 ```
 
 It’s recommanded to use a tool to build your svg sprite.
+
+## Integrate your local version into Colette
+
+1. Run `npm pack` to generate a compressed `.tgz` file of the project (e.g `colette-kss-builder-5.4.0.tgz`) on the root of the project
+2. On Colette's side, point to that file on the `package.json` and run `npm install`
+3. /!\ Be careful to not commit this file and/or the colette-kss-file path


### PR DESCRIPTION
KSS is no longer on beta and its v3 has been released.
This induced a malfunction of the symbols on Colette.

I also added the method to test our local version of colette-kss-builder with Colette on the readme, which can be very useful!