### PR TITLE
Drop node 1.x support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "./node_modules/.bin/webpack"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12"
   },
   "devDependencies": {
     "@accede-web/tablist": "^2.0.1",


### PR DESCRIPTION
Following https://github.com/20minutes/colette/pull/1217 on Colette, we drop Node 10.x support